### PR TITLE
 #49 Fix build for IE11

### DIFF
--- a/client-react/config/doc/webpack.config.js
+++ b/client-react/config/doc/webpack.config.js
@@ -9,12 +9,8 @@ const NODE_ENV = process.env.NODE_ENV;
 
 module.exports = {
   entry: [
-    // IE11 - "String.prototype.startsWith" and endsWith methods (local code)
-    "core-js/es6/string.js",
-    // IE11 - "Promise"s - required for autocompletes
+    // required for IE11
     "core-js/es6/promise.js",
-    // IE11 - Used in "slate-js" dependency code
-    "core-js/es7/array.js",
 
     path.resolve(__dirname, '../../www/index-page.js')
   ],

--- a/client-react/config/webpack.config.js
+++ b/client-react/config/webpack.config.js
@@ -53,7 +53,10 @@ if(WEBPACK_BUNDLE_ANALYZE && IS_PRODUCTION_MODE) {
   plugins.push(bundleAnalyzerPlugin);
 }
 
-const entries = [];
+const entries = [
+  // required for IE11
+  'core-js/es6/promise.js'
+];
 
 entries.push(
   (IS_PRODUCTION_MODE || IS_LINK_MODE) ?

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -93,6 +93,8 @@
     "@opuscapita/react-svg": "2.0.1",
     "@opuscapita/svg-icons": "1.1.1",
     "babel-preset-es2017": "6.24.1",
+    "base64url": "2.0.0",
+    "core-js": "2.5.0",
     "filesize": "3.5.11",
     "immutable": "3.8.2",
     "lodash": "4.17.4",

--- a/client-react/src/client/connectors/nodejs_v1/api.js
+++ b/client-react/src/client/connectors/nodejs_v1/api.js
@@ -1,5 +1,5 @@
 import request from 'superagent';
-import id from '../../../../../server-nodejs/utils/id';
+import id from './id';
 
 async function init(options) {
   options.onInitSuccess();

--- a/client-react/src/client/connectors/nodejs_v1/id.js
+++ b/client-react/src/client/connectors/nodejs_v1/id.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const base64url = require('base64url');
+
+function encode(path) {
+  if (typeof path !== 'string') {
+    throw new Error('Only strings can be base64-encoded');
+  }
+
+  return base64url(path);
+}
+
+function decode(id) {
+  if (typeof id !== 'string' || !id) {
+    throw new Error('Invalid id');
+  }
+
+  return base64url.decode(id);
+}
+
+module.exports = {
+  encode,
+  decode
+};


### PR DESCRIPTION
Note: sign-in to Google Drive on IE11 or Edge not allowed by sequrity
reasons.

Sign-in in react-client hosted on any trusted domain (for example -
"xxx.azurewebsites.net") works OK.

Some workaround should be found later.