### PR TITLE
Now devs can add header and parameters to all connector-node-v1 requests.

### DIFF
--- a/packages/connector-node-v1/src/api.js
+++ b/packages/connector-node-v1/src/api.js
@@ -24,14 +24,15 @@ function init() {
 
 function setupRequestOptions(options) {
   let newOptions = { ...options };
+
   if (!newOptions.header) {
     newOptions.header = {};
-  } else {
-    newOptions.header['Content-Type'] = 'application/json';
   }
+
   if (!newOptions.parameters) {
     newOptions.parameters = {};
   }
+
   return newOptions;
 }
 
@@ -52,7 +53,7 @@ async function getChildrenForId(options, { id, sortBy = 'name', sortDirection = 
   const route = `${options.apiRoot}/files/${id}/children?orderBy=${sortBy}&orderDirection=${sortDirection}`;
   const method = 'GET';
   const response = await request(method, route).set(requestOptions.header).query(requestOptions.parameters);
-  return response.body.items.map(normalizeResource)
+  return response.body.items.map(normalizeResource);
 }
 
 async function getParentsForId(options, id, result = []) {
@@ -78,7 +79,10 @@ async function getParentsForId(options, id, result = []) {
 
 async function getBaseResource(options) {
   const route = `${options.apiRoot}/files`;
-  const response = await request.get(route);
+  const requestOptions = setupRequestOptions(options);
+  const response = await request.get(route).
+    set(requestOptions.header).
+    query(requestOptions.parameters);
   return normalizeResource(response.body);
 }
 
@@ -120,6 +124,7 @@ async function getParentIdForResource(options, resource) {
 async function uploadFileToId({ apiOptions, parentId, file, onProgress }) {
   let route = `${apiOptions.apiRoot}/files`;
   const requestOptions = setupRequestOptions(apiOptions);
+
   return request.post(route).
     field('type', 'file').
     field('parentId', parentId).
@@ -187,7 +192,7 @@ async function removeResource(options, resource) {
 }
 
 async function removeResources(options, selectedResources) {
-  return Promise.all(selectedResources.map(resource => removeResource(options, resource)))
+  return Promise.all(selectedResources.map(resource => removeResource(options, resource)));
 }
 
 export default {

--- a/packages/connector-node-v1/src/api.js
+++ b/packages/connector-node-v1/src/api.js
@@ -22,6 +22,19 @@ function init() {
   };
 }
 
+function setupRequestOptions(options) {
+  let newOptions = { ...options };
+  if (!newOptions.header) {
+    newOptions.header = {};
+  } else {
+    newOptions.header['Content-Type'] = 'application/json';
+  }
+  if (!newOptions.parameters) {
+    newOptions.parameters = {};
+  }
+  return newOptions;
+}
+
 async function getCapabilitiesForResource(options, resource) {
   return resource.capabilities || [];
 }
@@ -29,14 +42,16 @@ async function getCapabilitiesForResource(options, resource) {
 async function getResourceById(options, id) {
   const route = `${options.apiRoot}/files/${id}`;
   const method = 'GET';
-  const response = await request(method, route);
+  const requestOptions = setupRequestOptions(options);
+  const response = await request(method, route).set(requestOptions.header).query(requestOptions.parameters);
   return normalizeResource(response.body);
 }
 
 async function getChildrenForId(options, { id, sortBy = 'name', sortDirection = 'ASC' }) {
+  const requestOptions = setupRequestOptions(options);
   const route = `${options.apiRoot}/files/${id}/children?orderBy=${sortBy}&orderDirection=${sortDirection}`;
   const method = 'GET';
-  const response = await request(method, route);
+  const response = await request(method, route).set(requestOptions.header).query(requestOptions.parameters);
   return response.body.items.map(normalizeResource)
 }
 
@@ -104,10 +119,13 @@ async function getParentIdForResource(options, resource) {
 
 async function uploadFileToId({ apiOptions, parentId, file, onProgress }) {
   let route = `${apiOptions.apiRoot}/files`;
+  const requestOptions = setupRequestOptions(apiOptions);
   return request.post(route).
     field('type', 'file').
     field('parentId', parentId).
     attach('files', file.file, file.name).
+    set(requestOptions.header).
+    query(requestOptions.parameters).
     on('progress', event => {
       onProgress(event.percent);
     });
@@ -118,8 +136,10 @@ async function downloadResources({ apiOptions, resources, onProgress }) {
     (url, resource, num) => url + (num === 0 ? '' : '&') + `items=${resource.id}`,
     `${apiOptions.apiRoot}/download?`
   );
-
+  const requestOptions = setupRequestOptions(apiOptions);
   let res = await request.get(downloadUrl).
+    set(requestOptions.header).
+    query(requestOptions.parameters).
     responseType('blob').
     on('progress', event => {
       onProgress(event.percent);
@@ -136,7 +156,11 @@ async function createFolder(options, parentId, folderName) {
     name: folderName,
     type: 'dir'
   };
-  return request(method, route).send(params)
+  const requestOptions = setupRequestOptions(options);
+  return request(method, route).
+    send(params).
+    set(requestOptions.header).
+    query(requestOptions.parameters);
 }
 
 function getResourceName(apiOptions, resource) {
@@ -146,13 +170,20 @@ function getResourceName(apiOptions, resource) {
 async function renameResource(options, id, newName) {
   const route = `${options.apiRoot}/files/${id}`;
   const method = 'PATCH';
-  return request(method, route).type('application/json').send({ name: newName })
+  const requestOptions = setupRequestOptions(options);
+  return request(method, route).type('application/json').
+    send({ name: newName }).
+    set(requestOptions.header).
+    query(requestOptions.parameters);
 }
 
 async function removeResource(options, resource) {
   const route = `${options.apiRoot}/files/${resource.id}`;
   const method = 'DELETE';
-  return request(method, route)
+  const requestOptions = setupRequestOptions(options);
+  return request(method, route).
+    set(requestOptions.header).
+    query(requestOptions.parameters);
 }
 
 async function removeResources(options, selectedResources) {

--- a/packages/connector-node-v1/src/capabilities/download.js
+++ b/packages/connector-node-v1/src/capabilities/download.js
@@ -8,6 +8,10 @@ import getMess from '../translations';
 
 let label = 'download';
 
+function toParams(data) {
+  return Object.keys(data).map(key => `${key}=${encodeURIComponent(data[key])}`).join('&');
+}
+
 async function handler(apiOptions, actions) {
   const {
     updateNotifications,
@@ -91,7 +95,7 @@ async function handler(apiOptions, actions) {
     const quantity = resources.length;
     if (quantity === 1) {
       const { id, name } = resources[0];
-      const downloadUrl = `${apiOptions.apiRoot}/download?items=${id}`;
+      const downloadUrl = `${apiOptions.apiRoot}/download?items=${id}&${toParams(apiOptions.parameters)}&${toParams(apiOptions.header)}`;
       // check if the file is available and trigger native browser saving prompt
       // if server is down the error will be catched and trigger relevant notification
       await api.getResourceById(apiOptions, id);
@@ -102,7 +106,7 @@ async function handler(apiOptions, actions) {
       onStart({ archiveName, quantity });
       const content = await api.downloadResources({ resources, apiOptions, onProgress });
       setTimeout(onSuccess, 1000);
-      promptToSaveBlob({ content, name: archiveName })
+      promptToSaveBlob({ content, name: archiveName });
     }
   } catch (err) {
     onFailError({
@@ -111,7 +115,7 @@ async function handler(apiOptions, actions) {
       notificationId,
       updateNotifications
     });
-    console.log(err)
+    console.log(err);
   }
 }
 
@@ -134,4 +138,4 @@ export default (apiOptions, actions) => {
     availableInContexts: ['row', 'toolbar'],
     handler: () => handler(apiOptions, actions)
   };
-}
+};


### PR DESCRIPTION
Now the user can add parameters and header elements to all requests like this:
``` javascript
const apiOptions = {
  ...connectorNodeV1.apiOptions,
  apiRoot: `http://opuscapita-filemanager-demo.azurewebsites.net/api`,
  header: {
    'Authorization': '1234'
  },
  parameters: {
    "userId": "1234"
  }
}
```
This is a very important feature to be able to integrate the file manager securely.