### PR TITLE
Add ability to call own methods on resource item events

### DIFF
--- a/packages/client-react/src/client/components/FileManager/FileManager.DOCUMENTATION.md
+++ b/packages/client-react/src/client/components/FileManager/FileManager.DOCUMENTATION.md
@@ -35,9 +35,6 @@ See [FileNavigator documentation and example](http://opuscapita-filemanager-demo
           </div>
         )}
         onLocationChange={_scope.handleNodejsLocationChange}
-        onResourceItemClick={({ event, number, rowData }) => {console.log('onResourceItemClick', event, number, rowData}}
-        onResourceItemDoubleClick={({ event, number, rowData }) => {console.log('onResourceItemDoubleClick', event, number, rowData}}
-        onResourceItemRightClick={({ event, number, rowData }) => {console.log('onResourceItemRightClick', event, number, rowData}}
       />
       
       {/* Use Google Drive API v2 connector */}

--- a/packages/client-react/src/client/components/FileManager/FileManager.DOCUMENTATION.md
+++ b/packages/client-react/src/client/components/FileManager/FileManager.DOCUMENTATION.md
@@ -35,6 +35,9 @@ See [FileNavigator documentation and example](http://opuscapita-filemanager-demo
           </div>
         )}
         onLocationChange={_scope.handleNodejsLocationChange}
+        onResourceItemClick={({ event, number, rowData }) => {console.log('onResourceItemClick', event, number, rowData}}
+        onResourceItemDoubleClick={({ event, number, rowData }) => {console.log('onResourceItemDoubleClick', event, number, rowData}}
+        onResourceItemRightClick={({ event, number, rowData }) => {console.log('onResourceItemRightClick', event, number, rowData}}
       />
       
       {/* Use Google Drive API v2 connector */}

--- a/packages/client-react/src/client/components/FileNavigator/FileNavigator.DOCUMENTATION.md
+++ b/packages/client-react/src/client/components/FileNavigator/FileNavigator.DOCUMENTATION.md
@@ -155,10 +155,10 @@ For **Massive Attack** folder in **Customization area => Music => Massive Attack
         ({ event, number, rowData }) => console.log('onResourceItemClick', event, number, rowData)
       }
       onResourceItemDoubleClick={
-        ({ event, number, rowData }) => console.log('onResourceItemClick', event, number, rowData)
+        ({ event, number, rowData }) => console.log('onResourceItemDoubleClick', event, number, rowData)
       }
       onResourceItemRightClick={
-        ({ event, number, rowData }) => console.log('onResourceItemClick', event, number, rowData)
+        ({ event, number, rowData }) => console.log('onResourceItemRightClick', event, number, rowData)
       }
     />
   </div>

--- a/packages/client-react/src/client/components/FileNavigator/FileNavigator.DOCUMENTATION.md
+++ b/packages/client-react/src/client/components/FileNavigator/FileNavigator.DOCUMENTATION.md
@@ -16,7 +16,10 @@ FileNavigator is
 | onResourceChange               | func                    | `resource => ...`                                                                              |
 | onResourceChildrenChange       | func                    | `resourceChildren => ...`                                                                      |
 | onResourceLocationChange       | func                    | `resourceLocation => ...`                                                                      |
-| onSelectionChange              | func                    | `selection` => ...` You can use `onSelectionChange` it in pair with `onResourceChildrenChange`        |
+| onSelectionChange              | func                    | `selection` => ...` You can use `onSelectionChange` it in pair with `onResourceChildrenChange` |
+| onResourceItemClick            | func                    |  `({ event, number, rowData }) => ...`                                                         |
+| onResourceItemDoubleClick      | func                    |  `({ event, number, rowData }) => ...`                                                         |
+| onResourceItemRightClick       | func                    |  `({ event, number, rowData }) => ...`                                                         |
 
 ### Connectors
 
@@ -147,6 +150,15 @@ For **Massive Attack** folder in **Customization area => Music => Massive Attack
       }
       onSelectionChange={
         selection => console.log('onSelectionChange', selection)
+      }
+      onResourceItemClick={
+        ({ event, number, rowData }) => console.log('onResourceItemClick', event, number, rowData)
+      }
+      onResourceItemDoubleClick={
+        ({ event, number, rowData }) => console.log('onResourceItemClick', event, number, rowData)
+      }
+      onResourceItemRightClick={
+        ({ event, number, rowData }) => console.log('onResourceItemClick', event, number, rowData)
       }
     />
   </div>

--- a/packages/client-react/src/client/components/FileNavigator/FileNavigator.react.js
+++ b/packages/client-react/src/client/components/FileNavigator/FileNavigator.react.js
@@ -49,6 +49,9 @@ const defaultProps = {
   listViewLayout: () => {},
   viewLayoutOptions: {},
   signInRenderer: null,
+  onResourceItemClick: () => {},
+  onResourceItemRightClick: () => {},
+  onResourceItemDoubleClick: () => {},
   onResourceLocationChange: () => {},
   onSelectionChange: () => {},
   onResourceChange: () => {},
@@ -275,15 +278,11 @@ class FileNavigator extends Component {
   };
 
   handleResourceItemClick = async ({ event, number, rowData }) => {
-    if (this.props.onResourceItemClick) {
       this.props.onResourceItemClick({ event, number, rowData });
-    }
   };
 
   handleResourceItemRightClick = async ({ event, number, rowData }) => {
-    if (this.props.onResourceItemRightClick) {
       this.props.onResourceItemRightClick({ event, number, rowData });
-    }
   };
 
   handleResourceItemDoubleClick = async ({ event, number, rowData }) => {
@@ -301,9 +300,7 @@ class FileNavigator extends Component {
 
     this.focusView();
 
-    if (this.props.onResourceItemDoubleClick) {
-      this.props.onResourceItemDoubleClick({ event, number, rowData });
-    }
+    this.props.onResourceItemDoubleClick({ event, number, rowData });
   };
 
   handleViewKeyDown = async (e) => {

--- a/packages/client-react/src/client/components/FileNavigator/FileNavigator.react.js
+++ b/packages/client-react/src/client/components/FileNavigator/FileNavigator.react.js
@@ -29,6 +29,7 @@ const propTypes = {
   listViewLayout: PropTypes.func,
   viewLayoutOptions: PropTypes.object,
   signInRenderer: PropTypes.func,
+  resourceItemDoubleClick: PropTypes.func,
   onResourceLocationChange: PropTypes.func,
   onSelectionChange: PropTypes.func,
   onResourceChange: PropTypes.func,
@@ -293,6 +294,10 @@ class FileNavigator extends Component {
     }
 
     this.focusView();
+
+    if (this.props.resourceItemDoubleClick) {
+      this.props.resourceItemDoubleClick();
+    }
   };
 
   handleViewKeyDown = async (e) => {

--- a/packages/client-react/src/client/components/FileNavigator/FileNavigator.react.js
+++ b/packages/client-react/src/client/components/FileNavigator/FileNavigator.react.js
@@ -29,7 +29,9 @@ const propTypes = {
   listViewLayout: PropTypes.func,
   viewLayoutOptions: PropTypes.object,
   signInRenderer: PropTypes.func,
-  resourceItemDoubleClick: PropTypes.func,
+  onResourceItemClick: PropTypes.func,
+  onResourceItemRightClick: PropTypes.func,
+  onResourceItemDoubleClick: PropTypes.func,
   onResourceLocationChange: PropTypes.func,
   onSelectionChange: PropTypes.func,
   onResourceChange: PropTypes.func,
@@ -273,11 +275,15 @@ class FileNavigator extends Component {
   };
 
   handleResourceItemClick = async ({ event, number, rowData }) => {
-
+    if (this.props.onResourceItemClick) {
+      this.props.onResourceItemClick({ event, number, rowData });
+    }
   };
 
   handleResourceItemRightClick = async ({ event, number, rowData }) => {
-
+    if (this.props.onResourceItemRightClick) {
+      this.props.onResourceItemRightClick({ event, number, rowData });
+    }
   };
 
   handleResourceItemDoubleClick = async ({ event, number, rowData }) => {
@@ -295,8 +301,8 @@ class FileNavigator extends Component {
 
     this.focusView();
 
-    if (this.props.resourceItemDoubleClick) {
-      this.props.resourceItemDoubleClick();
+    if (this.props.onResourceItemDoubleClick) {
+      this.props.onResourceItemDoubleClick({ event, number, rowData });
     }
   };
 


### PR DESCRIPTION
This PR could add the ability to add own handlers to resource items events. For example if you want to open your own image viewer by double clicking on image file in FileManager it would be impossible. You could only use onSelectionChange, which fires on single click. 

Release notes
---
Add the ability to call click, doubleClick and rightClick events handles through props, so that the user can call own actions on those events.
<!--  Write your release note:
Release notes are required for any PR with user-visible changes, such as bug-fixes, feature additions, and output format changes.
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
