### PR TITLE
Fix wrong API example link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import connectorNodeV1 from '@opuscapita/react-filemanager-connector-node-v1';
 
 const apiOptions = {
   ...connectorNodeV1.apiOptions,
-  apiRoot: `http://opuscapita-filemanager-demo.azurewebsites.net/api` // Or you local Server Node V1 installation.
+  apiRoot: `http://opuscapita-filemanager-demo-master.azurewebsites.net/` // Or you local Server Node V1 installation.
 }
 
 const fileManager = (


### PR DESCRIPTION
Example API methods aren't working for me while I use this link from README.md: http://opuscapita-filemanager-demo.azurewebsites.net/api 

So I decided to inspect a demo and found out that the url has changed to http://opuscapita-filemanager-demo-master.azurewebsites.net/ (this url returns something useful <a href="http://opuscapita-filemanager-demo-master.azurewebsites.net/files/">click</a>) Let's fix this example link so new users can get started without experiencing any issues! Thanks.