### PR TITLE
(Issue #228) Fix recursive queries to the API

### DIFF
--- a/packages/connector-node-v1/src/api.js
+++ b/packages/connector-node-v1/src/api.js
@@ -46,19 +46,10 @@ async function getParentsForId(options, id, result = []) {
   }
 
   const resource = await getResourceById(options, id);
-
-  if (!resource) {
-    return result;
+  if (resource && resource.ancestors) {
+    return resource.ancestors;
   }
-
-  const parentId = resource.parentId;
-
-  if (!parentId) {
-    return result;
-  }
-
-  const parent = await getResourceById(options, parentId);
-  return getParentsForId(options, resource.parentId, [parent, ...result]);
+  return result;
 }
 
 async function getBaseResource(options) {

--- a/packages/connector-node-v1/src/utils/common.js
+++ b/packages/connector-node-v1/src/utils/common.js
@@ -8,7 +8,8 @@ export function normalizeResource(resource) {
       name: resource.name,
       type: resource.type,
       size: resource.size,
-      parentId: resource.parentId ? resource.parentId : null
+      parentId: resource.parentId ? resource.parentId : null,
+      ancestors: resource.ancestors ? resource.ancestors : null
     };
   } else {
     return {};


### PR DESCRIPTION
This PR fixes too many queries sent to the API when using `connector-node-v1` and diving deeply into the filesystem (see https://github.com/OpusCapita/filemanager/issues/228 for more info). Tested this so far, works great :100:  

### Release Notes

Fix too many queries being sent to the API when diving deeply into the filesystem.
