### PR TITLE
(Issue #83) Made "LocationBar" scrollable for long locations

### DIFF
--- a/packages/client-react/src/client/components/FileManagerOne/FileManagerOne.less
+++ b/packages/client-react/src/client/components/FileManagerOne/FileManagerOne.less
@@ -19,6 +19,7 @@
 .oc-fm--file-manager__navigator {
   flex: 1;
   border-right: 1px solid rgba(0,0,0,.08);
+  max-width: 100%;
 
   &:last-child {
     border-right: none;

--- a/packages/client-react/src/client/components/LocationBar/LocationBar.less
+++ b/packages/client-react/src/client/components/LocationBar/LocationBar.less
@@ -8,6 +8,7 @@
 .oc-fm--location-bar {
   display: flex;
   overflow: hidden;
+  overflow-x: auto;
   position: relative;
 }
 


### PR DESCRIPTION
Hi team, 
@asergeev-sc @kvolkovich-sc 

Recently, I've faced issue when long location bar expands File Manager width, as a result part of content is hidden. This behavior is not acceptable for my usage and I have to fix it. 
![image](https://user-images.githubusercontent.com/22007521/77959425-3b83fa80-72df-11ea-8131-2c0c98a67055.png)

I didn't want to use my own copy of project, because it would cause some difficulties with updates, so I decided to contribute, furthermore I've found open [issue](https://github.com/OpusCapita/filemanager/issues/83) with similar request.

Open to your suggestions.