### PR TITLE
Use `type="button"` for Toolbar Buttons

### DIFF
--- a/packages/client-react/src/client/components/Toolbar/Toolbar.react.js
+++ b/packages/client-react/src/client/components/Toolbar/Toolbar.react.js
@@ -80,6 +80,7 @@ class Toolbar extends Component {
       <div data-test-id="toolbar" className="oc-fm--toolbar__items">
         {items.map((item, i) => (
           <button
+            type="button"
             key={i}
             data-test-id={`toolbar-item--${item.id}`}
             disabled={item.disabled}
@@ -100,6 +101,7 @@ class Toolbar extends Component {
 
     const newButtonElement = newButtonText ? (
       <button
+        type="button"
         onClick={this.handleShowDropdownMenu}
         className="oc-fm--toolbar__new-button"
       >
@@ -153,6 +155,7 @@ class Toolbar extends Component {
     const navButtons = (
       <div className="oc-fm--toolbar__nav-buttons">
         <button
+          type="button"
           disabled={!isHistoryStepPossible(history, -1)}
           className={`oc-fm--toolbar__item`}
           title={getMessage('moveBack')}
@@ -166,6 +169,7 @@ class Toolbar extends Component {
         </button>
 
         <button
+          type="button"
           disabled={!isHistoryStepPossible(history, 1)}
           className={`oc-fm--toolbar__item`}
           title={getMessage('moveForward')}


### PR DESCRIPTION
Normally, the toolbar buttons have no pre-set button type so the browser defaults them to `type="submit"`. This means that if a File Navigator is embedded within a larger HTML form, clicking any toolbar button or the back and next buttons will accidentally submit the form.

This change fixes that minor oversight by making the toolbar buttons `type="button"`. 

Release notes
---
* Now, the file manager control can be embedded within a larger form without accidentally submitting the form any time that a toolbar button is clicked.